### PR TITLE
Safeguard Muck

### DIFF
--- a/CruelBlinds_1_0_0/CruelBlinds.lua
+++ b/CruelBlinds_1_0_0/CruelBlinds.lua
@@ -787,6 +787,7 @@ SMODS.Blind	{
         return false
     end,
     in_pool = function(self)
+	if not G.jokers then return false end
         for i, j in pairs(G.jokers.cards) do
             if not ((j.config.center.rarity == 1) or (j.config.center.rarity == 2)) then
                 return true


### PR DESCRIPTION
A new steamodded change moves the showdown blind check into an `in_pool` option for consistency, this means Common Muck's in_pool func will be called even when generating the first boss, but G.jokers is not yet initialized at that time. This change safeguards against this crash